### PR TITLE
Added 'See All' Button on Dashboard view

### DIFF
--- a/src/components/Holdings/HoldingItem.tsx
+++ b/src/components/Holdings/HoldingItem.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 import accounting from 'accounting'
-import { Link } from 'react-router-dom'
+import { 
+  StylelessLink, 
+  Wrapper, 
+  VerticalMiddleContainer,
+  Indicator,
+  ItemContainer
+} from '../LongItem'
 
 import forwardIcon from '../../assets/forward.png'
-
-const StylelessLink = styled(Link)`
-  text-decoration: none;
-`
 
 const ColorStrip = styled.div`
   position: absolute;
@@ -16,20 +18,6 @@ const ColorStrip = styled.div`
   width: 6px;
   height: 100%;
   background-color: ${props => props.color || '#ffbf00'};
-`
-
-const HoldingDetails = styled.div`
-  padding-left: 20px;
-  text-align: left;
-  display: flex;
-  flex-direction: column;
-`
-
-const VerticalMiddleContainer = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
 `
 
 const HoldingTitle = styled(VerticalMiddleContainer)`
@@ -42,35 +30,7 @@ const HoldingTotal = styled(VerticalMiddleContainer)`
   font-size: 13px;
 `
 
-const Indicator = styled.div`
-  align-items: flex-end;
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  flex-direction: column;
-  padding-right: 10px;
-  text-align: right;
-
-  img {
-    width: 8px;
-    height: 14px;
-  }
-`
-
-const ItemContainer = styled.div`
-  background-color: #e8ebf4;
-  border-radius: 4px;
-  display: flex;
-  margin: auto;
-  margin-bottom: 10px;
-  max-width: 450px;
-  min-height: 65px;
-  overflow: hidden;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  position: relative;
-  width: 100%;
-
+const HoldingItemContainer = styled(ItemContainer)`
   &:hover {
     background-color: #7686a2;
     color: #fff !important;
@@ -96,16 +56,16 @@ const HoldingItem = ({
 }) => {
   return (
     <StylelessLink to={`/holdings/${id}`}>
-      <ItemContainer>
+      <HoldingItemContainer>
         <ColorStrip color={color} />
-        <HoldingDetails>
+        <Wrapper>
           <HoldingTitle>{name}</HoldingTitle>
           <HoldingTotal>{accounting.formatMoney(value)}</HoldingTotal>
-        </HoldingDetails>
+        </Wrapper>
         <Indicator>
           <img src={forwardIcon} alt="Forward" />
         </Indicator>
-      </ItemContainer>
+      </HoldingItemContainer>
     </StylelessLink>
   )
 }

--- a/src/components/LongButton.tsx
+++ b/src/components/LongButton.tsx
@@ -1,64 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
-
 import forwardIcon from '../assets/forward.png'
-
-const StylelessLink = styled(Link)`
-  text-decoration: none;
-`
-
-const VerticalMiddleContainer = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-`
-
-const TextWrapper = styled.div`
-  padding-left: 20px;
-  text-align: left;
-  display: flex;
-  flex-direction: column;
-`
+import { 
+  StylelessLink, 
+  Wrapper, 
+  VerticalMiddleContainer,
+  Indicator,
+  ItemContainer
+} from './LongItem'
 
 const TextTitle = styled(VerticalMiddleContainer)`
   color: #2a364a;
   font-size: 18px;
 `
-const Indicator = styled.div`
-  align-items: flex-end;
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  flex-direction: column;
-  padding-right: 10px;
-  text-align: right;
-
-  img {
-    width: 8px;
-    height: 14px;
-  }
-`
-
-const ItemContainer = styled.div`
-  background-color: #ffffff;
-  border-radius: 4px;
-  display: flex;
-  margin: auto;
-  margin-bottom: 10px;
-  max-width: 450px;
-  min-height: 65px;
-  overflow: hidden;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  position: relative;
-  width: 100%;
-
-  border: 1px solid #E8EBF4;
-  box-sizing: border-box;
-  border-radius: 4px;
-
+const TextContainer = styled(ItemContainer)`
   &:hover {
     background-color: #f8f8ff;
     cursor: pointer;
@@ -72,14 +27,14 @@ interface LongButton {
 const LongButton = ({text}) => {
   return (
     <StylelessLink to={`/holdings`}>
-      <ItemContainer>
-        <TextWrapper>
+      <TextContainer>
+        <Wrapper>
           <TextTitle>{text}</TextTitle>
-        </TextWrapper>
+        </Wrapper>
         <Indicator>
           <img src={forwardIcon} alt="Forward" />
         </Indicator>
-      </ItemContainer>
+      </TextContainer>
     </StylelessLink>
   )
 }

--- a/src/components/LongButton.tsx
+++ b/src/components/LongButton.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+import forwardIcon from '../assets/forward.png'
+
+const StylelessLink = styled(Link)`
+  text-decoration: none;
+`
+
+const VerticalMiddleContainer = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`
+
+const TextWrapper = styled.div`
+  padding-left: 20px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+`
+
+const TextTitle = styled(VerticalMiddleContainer)`
+  color: #2a364a;
+  font-size: 18px;
+`
+const Indicator = styled.div`
+  align-items: flex-end;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  flex-direction: column;
+  padding-right: 10px;
+  text-align: right;
+
+  img {
+    width: 8px;
+    height: 14px;
+  }
+`
+
+const ItemContainer = styled.div`
+  background-color: #ffffff;
+  border-radius: 4px;
+  display: flex;
+  margin: auto;
+  margin-bottom: 10px;
+  max-width: 450px;
+  min-height: 65px;
+  overflow: hidden;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  position: relative;
+  width: 100%;
+
+  border: 1px solid #E8EBF4;
+  box-sizing: border-box;
+  border-radius: 4px;
+
+  &:hover {
+    background-color: #f8f8ff;
+    cursor: pointer;
+  }
+`
+
+interface LongButton {
+    text: String
+}
+  
+const LongButton = ({text}) => {
+  return (
+    <StylelessLink to={`/holdings`}>
+      <ItemContainer>
+        <TextWrapper>
+          <TextTitle>{text}</TextTitle>
+        </TextWrapper>
+        <Indicator>
+          <img src={forwardIcon} alt="Forward" />
+        </Indicator>
+      </ItemContainer>
+    </StylelessLink>
+  )
+}
+
+export default LongButton;

--- a/src/components/LongItem.tsx
+++ b/src/components/LongItem.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+export const StylelessLink = styled(Link)`
+    text-decoration: none;
+`
+
+export const VerticalMiddleContainer = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+`
+
+export const Wrapper = styled.div`
+  padding-left: 20px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+`
+
+export const Indicator = styled.div`
+  align-items: flex-end;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  flex-direction: column;
+  padding-right: 10px;
+  text-align: right;
+
+  img {
+    width: 8px;
+    height: 14px;
+  }
+`
+
+
+export const ItemContainer = styled.div`
+  background-color: #e8ebf4;
+  border-radius: 4px;
+  display: flex;
+  margin: auto;
+  margin-bottom: 10px;
+  max-width: 450px;
+  min-height: 65px;
+  overflow: hidden;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  position: relative;
+  width: 100%;
+`

--- a/src/views/Dashboard.js
+++ b/src/views/Dashboard.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import HoldingsList from '../components/Holdings/HoldingsList'
 import { PieChart, Pie, Cell } from 'recharts'
+import LongButton from '../components/LongButton'
 import db from '../db'
 
 const Flex = styled.div`
@@ -44,6 +45,7 @@ const Dashboard = () => {
         </Column>
         <Column>
           <HoldingsList holdings={holdings} />
+          <LongButton text="See All"/>
         </Column>
       </Flex>
     </div>


### PR DESCRIPTION
# Description

A new long-button component was added that takes in a string to represent the text within the button. This was to be consistent with the holding buttons on the dashboard. Also chose a hover highlight colour (#f8f8ff) which imo works well with the white. 

Fixes: #4 

## Type of change
Enhancement
# Screenshots (if applicable):
![](https://i.gyazo.com/57103c1e5f68accab9ea0792331b7220.png)
