### PR TITLE
Quick style fix for button backgrounds

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,6 +14,7 @@ const StyledButton = styled.button<StyledButton>`
   font-weight: 500;
   padding: 20px 40px;
   outline: none;
+  background-color: #ffffff;
 
   &:focus {
     box-shadow: 0px 0px 2px #2a364a;

--- a/src/components/Holdings/HoldingModal.tsx
+++ b/src/components/Holdings/HoldingModal.tsx
@@ -44,6 +44,7 @@ const CancelButton = styled.button`
   position: absolute;
   right: 30px;
   top: 20px;
+  background-color: #ffffff;
 `
 
 const ModalBody = styled.div`


### PR DESCRIPTION
# Description

Quick styling change according to the figma mocks. Just removed the grey background from buttons/cancel on the modal

Fixes: # (issue)

## Type of change
Enhancement
# Screenshots (if applicable):
![](https://i.gyazo.com/3ed85f878da456c60954d6c0b4db3442.png)
![](https://i.gyazo.com/2a7310a6225940efd19d5af43c512b4e.png)
![](https://i.gyazo.com/b7cc73f5a75002598bb4578f67267994.png)


