### PR TITLE
Export data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "accounting": "^0.4.1",
     "axios": "^0.19.0",
     "blockstack": "^19.2.1",
+    "json2csv": "^4.5.2",
     "lowdb": "^1.0.0",
     "react": "^16.8.6",
     "react-color": "^2.17.3",

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -4,16 +4,18 @@ export const exportData = (data) => {
     const fileName = new Date().toISOString().slice(0, 10) + '-data'
 
     // Current list of fields we want to export
-    const fields = ['id', 'name', 'value', 'color', 'currency', 'convertedValue', 'totalValue']
+    const fields = ['id', 'name', 'value', 'color', 
+                    'currency', 'convertedValue', 'totalValueInSetCurrency']
 
-    // Add in the totalValue to make parsing easier in the json.
+    // Add in the totalValue to make parsing easier in the json. Total value is relative to global currency state.
     let totalValue = {
-        'totalValueInGlobalCurrency' : 0
+        'totalValueInSetCurrency' : 0
     }
 
     // Sum the converted value
     data.forEach((obj) => {
-        totalValue['totalValue'] += obj['convertedValue']
+        totalValue['totalValueInSetCurrency'] += obj['convertedValue']
+
     })
     data.push(totalValue)
 

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,6 +1,9 @@
 import { Parser } from 'json2csv'
+import { convertedValue } from './holding'
 
 export const exportData = (data) => {
+    // Need to make a copy since pass by reference
+    let tempData = [...data]
     const fileName = new Date().toISOString().slice(0, 10) + '-data'
 
     // Current list of fields we want to export
@@ -13,15 +16,16 @@ export const exportData = (data) => {
     }
 
     // Sum the converted value
-    data.forEach((obj) => {
+    tempData.forEach((obj) => {
+        obj['convertedValue'] = convertedValue(obj)
         totalValue['totalValueInSetCurrency'] += obj['convertedValue']
 
     })
-    data.push(totalValue)
+    tempData.push(totalValue)
 
     // Parse the data
     const parser = new Parser({ fields })
-    let csv = parser.parse(data)
+    let csv = parser.parse(tempData)
 
     // Allow it to be downloadable
     let link = document.createElement('a')

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,32 @@
+import { Parser } from 'json2csv'
+
+export const exportData = (data) => {
+    const fileName = new Date().toISOString().slice(0, 10) + '-data'
+
+    // Current list of fields we want to export
+    const fields = ['id', 'name', 'value', 'color', 'currency', 'convertedValue', 'totalValue']
+
+    // Add in the totalValue to make parsing easier in the json.
+    let totalValue = {
+        'totalValueInGlobalCurrency' : 0
+    }
+
+    // Sum the converted value
+    data.forEach((obj) => {
+        totalValue['totalValue'] += obj['convertedValue']
+    })
+    data.push(totalValue)
+
+    // Parse the data
+    const parser = new Parser({ fields })
+    let csv = parser.parse(data)
+
+    // Allow it to be downloadable
+    let link = document.createElement('a')
+    link.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv))
+    link.setAttribute('download', fileName)
+    link.style.visibility = 'hidden'
+    document.body.appendChild(link)
+    link.click();
+    document.body.removeChild(link)
+}

--- a/src/utils/holding.ts
+++ b/src/utils/holding.ts
@@ -18,7 +18,5 @@ export const convertedValue = (holding: Holding) => {
   const globalCurrencyValue: number =
     euroValue * (globalCurrency.euro_rate || 1)
 
-  db.get('currencies').find({ code: holding.currency }).assign({convertedValue: globalCurrencyValue}).write()
-    
   return Math.round(globalCurrencyValue)
 }

--- a/src/utils/holding.ts
+++ b/src/utils/holding.ts
@@ -18,5 +18,7 @@ export const convertedValue = (holding: Holding) => {
   const globalCurrencyValue: number =
     euroValue * (globalCurrency.euro_rate || 1)
 
+  db.get('currencies').find({ code: holding.currency }).assign({convertedValue: globalCurrencyValue}).write()
+    
   return Math.round(globalCurrencyValue)
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -15,6 +15,9 @@ import {
   logoutFromBlockstack,
   isLoggedIn
 } from '../utils/blockstack'
+import {
+  exportData
+} from '../utils/export'
 
 const FlexColumn = styled(Flex)`
   flex-direction: column;
@@ -37,6 +40,10 @@ const Settings = () => {
   const currency: Currency = db
     .get('currencies')
     .find({ code: currentGlobalCurrencyCode })
+    .value()
+
+  const holdings = db
+    .get('holdings')
     .value()
 
   return (
@@ -69,7 +76,12 @@ const Settings = () => {
               icon={syncIcon}
             />
           )}
-          <SettingsItem text="Export Data" link="#" icon={exportIcon} />
+          <SettingsItem 
+            text="Export Data" 
+            link="#"
+            onClick={() => exportData(holdings)} 
+            icon={exportIcon} 
+          />
         </LeftColumn>
         <LeftColumn>
           <h3>About</h3>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,7 +2753,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.11.0, commander@^2.19.0, commander@~2.20.0:
+commander@^2.11.0, commander@^2.15.1, commander@^2.19.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -6152,6 +6152,15 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2csv@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.5.2.tgz#75f0808cb89ed8ef7e338445a510a3cd3e385dfe"
+  integrity sha512-Te2Knce3VfLKyurH3AolM6Y781ZE+R3jQ+0YQ0HYLiubyicST/19vML24e1dpScaaEQb+1Q1t5IcGXr6esM9Lw==
+  dependencies:
+    commander "^2.15.1"
+    jsonparse "^1.3.1"
+    lodash.get "^4.4.2"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -6182,6 +6191,11 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonparse@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsontokens@^1.0.0:
   version "1.0.0"
@@ -6401,6 +6415,11 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.map@^4.4.0:
   version "4.6.0"


### PR DESCRIPTION
# Description
Added in the ability to export data as a csv file. Currently the total value column is relative to the global currency state although depending on the desired usage that could always be changed.

Also changed was writing back to the db on `convertedValue()` in `holding.ts` so that the convertedValue in each holding is updated. 

Attached is also a copy of the csv file generated in pdf format (github doesn't support csv files)
[2019-07-12-data.pdf](https://github.com/lannister-capital/lannister-app/files/3384652/2019-07-12-data.pdf)


Fixes: #26 

## Type of change
Enhancement
# Screenshots (if applicable):
