### PR TITLE
Display percentage of each holding on chart

### DIFF
--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import accounting from 'accounting'
 import styled from 'styled-components'
 import HoldingsList from '../components/Holdings/HoldingsList'
 import { Flex, Column } from '../components/Grid'
-import { PieChart, Pie, Cell } from 'recharts'
+import { PieChart, Pie, Cell, Label } from 'recharts'
 import LongButton from '../components/LongButton'
 import db from '../db'
 import { convertedValue } from '../utils/holding'
@@ -14,6 +14,7 @@ const TotalValue = styled.div`
 `
 
 const Dashboard = () => {
+  const [percent, setPercent] = useState('%')
   const [holdings, setHoldings] = useState<Holding[]>([])
 
   // TODO: do not retrieve this everytime but allow immediate updates
@@ -36,6 +37,15 @@ const Dashboard = () => {
     setHoldings(allHoldings)
   }, [])
 
+  const handleMouseOver = useCallback((cell) => {
+    let value = (cell.percent * 100).toFixed(2) + "%"
+    setPercent(value)
+  }, [])
+
+  const handleMouseOut = useCallback(() => {
+    setPercent("%")
+  }, [])
+
   const totalHoldingsValue = holdings.reduce((a, b) => a + convertedValue(b), 0)
 
   return (
@@ -56,7 +66,13 @@ const Dashboard = () => {
               innerRadius={70}
               outerRadius={90}
               fill="#82ca9d"
-              label>
+              label
+              onMouseEnter={handleMouseOver}
+              onMouseOut={handleMouseOut}
+              >
+              <Label fontSize="35" fill="#7686A2" offset={0} position="center">
+                { percent }
+              </Label>
               {holdings.map((holding, index) => (
                 <Cell key={`cell-${index}`} fill={holding.color} />
               ))}

--- a/src/views/Holding.tsx
+++ b/src/views/Holding.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
 import accounting from 'accounting'
-import { PieChart, Pie, Cell } from 'recharts'
+import { PieChart, Pie, Cell, Label } from 'recharts'
 import Button from '../components/Button'
 import { Flex, Column, RightAlignContainer } from '../components/Grid'
 import db from '../db'
@@ -27,6 +27,7 @@ const Holding = (props: { match: { params: { id: string } } }) => {
   const id = props.match.params.id
   const [openHoldingModal, setOpenHoldingModal] = useState(false)
   const [openTransactionModal, setOpenTransactionModal] = useState(false)
+  const [percent, setPercent] = useState('%')
 
   const holdings = db.read('holdings').value().holdings
   const totalHoldingsValue = holdings.reduce((a, b) => a + b.value, 0)
@@ -38,6 +39,15 @@ const Holding = (props: { match: { params: { id: string } } }) => {
     .get('currencies')
     .find({ code: holding.currency })
     .value()
+  
+  const handleMouseOver = useCallback((cell) => {
+    let value = (cell.percent * 100).toFixed(2) + "%"
+    setPercent(value)
+  }, [])
+
+  const handleMouseOut = useCallback(() => {
+    setPercent("%")
+  }, [])
 
   return (
     <div>
@@ -75,7 +85,12 @@ const Holding = (props: { match: { params: { id: string } } }) => {
               innerRadius={70}
               outerRadius={90}
               fill="#82ca9d"
+              onMouseEnter={handleMouseOver}
+              onMouseOut={handleMouseOut}
               label>
+                <Label fontSize="35" fill="#7686A2" offset={0} position="center">
+                  { percent }
+                </Label>
               <Cell fill={holding.color} />
             </Pie>
           </PieChart>


### PR DESCRIPTION
# Description

Mouse overing now produces a percentage in the middle of the pie chart. This is changed in both the dashboard as well as in the holding view

Fixes: #27

## Type of change
Enhancement

# Screenshots (if applicable):
