### PR TITLE
Removed sync subtitle on settings.

### DIFF
--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -68,7 +68,6 @@ const Settings = () => {
           {!isLoggedIn() && (
             <SettingsItem
               text="Sync with Blockstack"
-              subtext="(beta, does not sync with mobile version)"
               onClick={() => loginWithBlockstack()}
               icon={syncIcon}
             />


### PR DESCRIPTION
# Description

Removes text `"(beta, does not sync with mobile version)"` on Settings.